### PR TITLE
Docker updates

### DIFF
--- a/bin/spannerTailerService_build_and_run.sh
+++ b/bin/spannerTailerService_build_and_run.sh
@@ -2,4 +2,9 @@
 
 set -ef
 
-docker build -t spez/spanner-tailer-service -f cdc/docker/Dockerfile.SpannerTailerService . && docker run -p 9010:9010 -t spez/spanner-tailer-service:latest
+CONTAINER_NAME=spanner-tailer
+
+docker container kill $CONTAINER_NAME || echo
+
+docker build -t spez/spanner-tailer-service -f cdc/docker/Dockerfile.SpannerTailerService . && \
+	docker run --name $CONTAINER_NAME -p 9010:9010 -t --rm spez/spanner-tailer-service:latest

--- a/cdc/docker/Dockerfile.SpannerTailerService
+++ b/cdc/docker/Dockerfile.SpannerTailerService
@@ -12,15 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gradle:latest AS build-env
+ENV JVM_HEAP_SIZE=6g
+ARG JDK_VERSION=11
+FROM openjdk:${JDK_VERSION}-jdk-slim as build-env
+# Get gradle distribution
+COPY *.gradle gradle.* gradlew /app/
+COPY gradle /app/gradle
+RUN /app/gradlew --version
+
+FROM build-env as app-build
 ADD . /app
 WORKDIR /app
 USER root
-RUN ./gradlew :cdc:spannerTailerService && \
-  mv cdc/build/libs/Main-fat-uber.jar Main.jar
+RUN ./gradlew clean :cdc:spannerTailerService && \
+  mv cdc/build/libs/Main-fat-*.jar Main.jar
 
-FROM gcr.io/distroless/java
-COPY --from=build-env /app/Main.jar /app/Main.jar
+FROM gcr.io/distroless/java:${JDK_VERSION}
+COPY --from=app-build /app/Main.jar /app/Main.jar
 ## This line is for local testing and should be commented out !!!
 ADD secrets /var/run/secret/cloud.google.com
 ENV GOOGLE_APPLICATION_CREDENTIALS /var/run/secret/cloud.google.com/service-account.json
@@ -30,7 +38,9 @@ ENTRYPOINT ["java", \
   "-Djava.net.preferIPv4Stack=true", \
   "-Dio.netty.allocator.type=pooled", \
   "-XX:+UseStringDeduplication", \
+  "-XX:+HeapDumpOnOutOfMemoryError", \
   "-XX:+UseG1GC", \
+  "-Xmx${JVM_HEAP_SIZE}", \
   "-Dcom.sun.management.jmxremote", \
   "-Dcom.sun.management.jmxremote.port=9010", \
   "-Dcom.sun.management.jmxremote.rmi.port=9010", \


### PR DESCRIPTION
#  cdc/docker/Dockerfile.SpannerTailerService

    Several tweaks to Dockerfile build
    
    * Base the build off openjdk:11-jdk-slim instead of gradle:latest.
      * This makes our build more consistent by using the gradle wrapper
        into the repo instead of the version of gradle in the base env.
    * Use build arg JDK_VERSION to specify base image.
    * Copy our gradle wrapper and environment into the image.
      * We can eventually use this with some caching to speed up the
        docker build.
    * Run `clean` so our builds aren't relying on dirty artifacts.
    * Use fileglobbing to create Main.jar.
      * This keeps things from breaking once we start making versioned
        releases.
    * Build arg JDK_VERSION used to determine `gcr.io/distroless/java`
      runtime version.
    * Turn on `HeapDumpOnOutOfMemoryError`.
    * Allow max heap size to be set by `JVM_HEAP_SIZE` env variable.
      * Currently defaults to 6GB.

#  bin/spannerTailerService_build_and_run.sh

    Reduce headaches with the docker script.
    
    * Give the container a name
    * Kill the named container if it's running (might be overkill)
    * Autoremove the container when it's done running
