### PR TITLE
Single Database instance, Single poller

### DIFF
--- a/cdc/docker/Dockerfile.SpannerTailerService
+++ b/cdc/docker/Dockerfile.SpannerTailerService
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ENV JVM_HEAP_SIZE=6g
 ARG JDK_VERSION=11
 FROM openjdk:${JDK_VERSION}-jdk-slim as build-env
 # Get gradle distribution
@@ -33,6 +32,7 @@ COPY --from=app-build /app/Main.jar /app/Main.jar
 ADD secrets /var/run/secret/cloud.google.com
 ENV GOOGLE_APPLICATION_CREDENTIALS /var/run/secret/cloud.google.com/service-account.json
 WORKDIR /app
+ENV JVM_HEAP_SIZE=6g
 ENTRYPOINT ["java", \
   "-ea", \
   "-Djava.net.preferIPv4Stack=true", \


### PR DESCRIPTION
* Use a single Database object throughout the life of the SpannerTailer.
* Do not allow more than one poller instace to execute the streaming
  query at the same time.
* Disable the uniq check and assume that the table doesn't have
  duplicate data.